### PR TITLE
BUG: Add curl-dev to module-ci

### DIFF
--- a/Docker/module-ci/Dockerfile
+++ b/Docker/module-ci/Dockerfile
@@ -5,6 +5,7 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repos
   && apk update \
   && apk add \
     curl \
+    curl-dev \
     cmake \
     expat-dev \
     g++ \


### PR DESCRIPTION
To address:

  curl: (48) An unknown option was passed in to libcurl

As suggested here:

  https://stackoverflow.com/questions/11678085/curl-48-an-unknown-option-was-passed-in-to-libcurl