### PR TITLE
ENH: Update module-ci docker base image version to 18.01.0

### DIFF
--- a/Docker/module-ci/Dockerfile
+++ b/Docker/module-ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:17.06.1-ce-git
+FROM docker:18.01.0-ce-git
 MAINTAINER Matt McCormick <matt.mccormick@kitware.com>
 
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories \


### PR DESCRIPTION
This also re-installs the Alpine packages, which will bump CMake to 3.9.5 and
fix the GitHub external module builds.